### PR TITLE
Fix to mmio access + misc cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+*~
+kvm-huge-guest-test
+leaktest-legacy-kvm
+vfio-correctness-tests
+vfio-huge-guest-test
+vfio-iommu-map-unmap
+vfio-iommu-stress-test
+vfio-noiommu-pci-device-open
+vfio-pci-device-open
+vfio-pci-device-open-igd
+vfio-pci-device-open-sparse-mmap
+vfio-pci-hot-reset

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+PROGS = kvm-huge-guest-test \
+	leaktest-legacy-kvm \
+	vfio-correctness-tests \
+	vfio-huge-guest-test \
+	vfio-iommu-map-unmap \
+	vfio-iommu-stress-test \
+	vfio-noiommu-pci-device-open \
+	vfio-pci-device-open \
+	vfio-pci-device-open-igd \
+	vfio-pci-device-open-sparse-mmap \
+	vfio-pci-hot-reset
+
+all: $(PROGS)
+
+clean:
+	rm -f *.o *~
+	rm -f $(PROGS)
+

--- a/vfio-correctness-tests.c
+++ b/vfio-correctness-tests.c
@@ -387,6 +387,7 @@ struct vfio_iommu_type1_dma_unmap {
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
+#include <stdlib.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <sys/param.h>

--- a/vfio-huge-guest-test.c
+++ b/vfio-huge-guest-test.c
@@ -386,6 +386,7 @@ struct vfio_iommu_type1_dma_unmap {
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
+#include <stdlib.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <sys/param.h>

--- a/vfio-iommu-map-unmap.c
+++ b/vfio-iommu-map-unmap.c
@@ -13,8 +13,10 @@
 #include <linux/ioctl.h>
 #include <linux/vfio.h>
 
-#define MAP_SIZE (1UL * 1024 * 1024 * 1024)
-#define MAP_CHUNK (4 * 1024)
+#define MAP_CHUNK (getpagesize())
+#define MAP_LIMIT 65535U
+#define MAP_SIZE (MAP_LIMIT * MAP_CHUNK)
+#define ITERATIONS 10
 #define REALLOC_INTERVAL 30
 
 void usage(char *name)
@@ -137,7 +139,7 @@ int main(int argc, char **argv)
 
 	memset(maps, 0, sizeof(void *) * (MAP_SIZE/dma_map.size));
 
-	for (count = 0;; count++) {
+	for (count = 0;count < ITERATIONS; count++) {
 
 		/* Every REALLOC_INTERVAL, dump our mappings to give THP something to collapse */
 		if (count % REALLOC_INTERVAL == 0) {

--- a/vfio-pci-device-open.c
+++ b/vfio-pci-device-open.c
@@ -570,14 +570,16 @@ int main(int argc, char **argv)
 			void *map = mmap(NULL, (size_t)region_info.size,
 					 PROT_READ, MAP_SHARED, device,
 					 (off_t)region_info.offset);
+			volatile unsigned char *p = map;
+			size_t j;
 			if (map == MAP_FAILED) {
 				printf("mmap failed\n");
 				continue;
 			}
 
 			printf("[");
-			fwrite(map, 1, region_info.size > 16 ? 16 :
-						region_info.size, stdout);
+			for (j = 0; j < 16 && j < region_info.size; j++)
+				printf("%02x ", p[j]);
 			printf("]\n");
 			munmap(map, (size_t)region_info.size);
 		}


### PR DESCRIPTION
Hi Alex, I realize this repo hasn't been much touched in years, but I'm using some of these tests while working on SR-IOV with Kata, so I thought I might as well push these fixes back.

The main thing here is a slightly polished version of Pradipta's fix (https://github.com/bpradipt/tests/commit/d884a0c1b40ddae15d945b792da60bb0c10041b2) with an actual commit message with rationale.  While I was doing that, I did some other trivial quality-of-life cleanups.
